### PR TITLE
Fix issue with parent context for selects with complex css selectors

### DIFF
--- a/lib/WWW/WebKit2/Locator.pm
+++ b/lib/WWW/WebKit2/Locator.pm
@@ -364,29 +364,25 @@ my $get_elements_function = q{
 =cut
 
 sub prepare_element {
-    my ($self) = @_;
+    my ($self, $element_name) = @_;
+
+    $element_name //= 'element';
 
     my $locator = $self->resolved_locator;
 
-    my ($get_parent, $parent_param) = ('', '');
+    my ($parent, $parent_param) = ('', '');
 
     if ($self->locator_parent) {
 
-        my $locator_string_parent = $self->locator_parent->resolve_locator;
-
-        $get_parent = "
-            var parent = getElementsByXPath('" . $locator_string_parent . "');
-            parent = parent[0];
-        ";
-
+        $parent = $self->locator_parent->prepare_element('parent');
         $parent_param = ", parent";
     }
 
     my $search = "
         $get_elements_function
-        $get_parent
-        var element = getElementsByXPath('$locator'$parent_param);
-        element = element[0];
+        $parent
+        var $element_name = getElementsByXPath('$locator'$parent_param);
+        $element_name = $element_name" . "[0];
     ";
 
     return $search;

--- a/lib/WWW/WebKit2/LocatorCSS.pm
+++ b/lib/WWW/WebKit2/LocatorCSS.pm
@@ -39,7 +39,9 @@ sub prepare_element {
 =cut
 
 sub prepare_elements {
-    my ($self) = @_;
+    my ($self, $element_name) = @_;
+
+    $element_name //= 'element';
 
     my $locator = $self->resolved_locator;
 

--- a/t/mouse.t
+++ b/t/mouse.t
@@ -30,6 +30,8 @@ $webkit->select('.//select[@name="dropdown_list"]', './/option[@value="testtwo"]
 my $updated_select_value = $webkit->resolve_locator('.//select[@name="dropdown_list"]')->property_search('selectedOptions[0].value');
 is($updated_select_value, 'testtwo', 'Test Two is the new selected value');
 
+$webkit->select('css=#body .form select[name="dropdown_list"]', 'label=Testone');
+
 my $radio_value = $webkit->resolve_locator('.//input[@id="radiotest_one"]')->property_search('checked');
 is($radio_value, '"false"', 'Radio value is currently false');
 $webkit->check('.//input[@id="radiotest_one"]');

--- a/t/test/mouse_input.html
+++ b/t/test/mouse_input.html
@@ -43,8 +43,8 @@
         }
     </style>
 </head>
-<body>
-    <form>
+<body id="body">
+    <form class="form">
         <select name="dropdown_list" id="dropdown_list">
             <option>Please select</option>
             <option value="testone">Testone</option>


### PR DESCRIPTION
This issue happened when the select-locator was a complex css selector,
because the current logic tried to evaluate this selector always with xpath.