### PR TITLE
Fire change event when clicking on a checkbox

### DIFF
--- a/lib/WWW/WebKit2/MouseInput.pm
+++ b/lib/WWW/WebKit2/MouseInput.pm
@@ -45,6 +45,7 @@ sub change_check {
     else {
         $element->remove_attribute('checked');
     }
+    $element->fire_event('change');
 
     return 1;
 }


### PR DESCRIPTION
According to: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
change events are also fired when setting "checked" on a checkbox or radio-button element via clicks or keyboard inputs.
Since the change_check only sets the attribute directly, it will not automatically trigger this event, but since it simulates a click, we should fire it anyway.