### PR TITLE
Remove json encode/decode madness

### DIFF
--- a/lib/WWW/WebKit2/Inspector.pm
+++ b/lib/WWW/WebKit2/Inspector.pm
@@ -16,7 +16,7 @@ sub run_javascript {
     $self->view->run_javascript($javascript_string, undef, sub {
         my ($object, $result, $user_data) = @_;
         $done = 1;
-        $js_result = $self->get_json_from_javascript_result($result);
+        $js_result = $self->get_javascript_result($result);
     }, undef);
 
     Gtk3::main_iteration while Gtk3::events_pending or not $done;
@@ -24,7 +24,7 @@ sub run_javascript {
     return $js_result;
 }
 
-sub get_json_from_javascript_result {
+sub get_javascript_result {
     my ($self, $result) = @_;
 
     my $value = $self->view->run_javascript_finish($result);
@@ -35,9 +35,8 @@ sub get_json_from_javascript_result {
     return $js_value->to_string if $js_value->is_string;
 
     my $json = JSON->new;
-    $json = encode_json($js_value->to_string);
 
-    return $json;
+    return $js_value->to_string;
 }
 
 =head3 resolve_locator
@@ -113,14 +112,8 @@ sub get_text {
 
 sub eval_js {
     my ($self, $javascript_string) = @_;
-    my $evaluated = $self->run_javascript($javascript_string);
 
-    my $decoded_json = eval { decode_json($evaluated) };
-    if ($@) {
-        return $evaluated;
-    }
-
-    return $decoded_json;
+    return $self->run_javascript($javascript_string);
 }
 
 =head3 get_xpath_count

--- a/lib/WWW/WebKit2/Locator.pm
+++ b/lib/WWW/WebKit2/Locator.pm
@@ -145,7 +145,7 @@ sub get_property {
 sub get_offset_width {
     my ($self) = @_;
 
-    return decode_json $self->property_search('offsetWidth');
+    return $self->property_search('offsetWidth');
 }
 
 =head2 get_offset_height
@@ -155,7 +155,7 @@ sub get_offset_width {
 sub get_offset_height {
     my ($self) = @_;
 
-    return decode_json $self->property_search('offsetHeight');
+    return $self->property_search('offsetHeight');
 }
 
 =head2 get_checked
@@ -197,7 +197,7 @@ sub get_length {
 
     my $search = $self->prepare_elements_search('length');
 
-    return decode_json $self->inspector->run_javascript($search);
+    return $self->inspector->run_javascript($search);
 }
 
 =head2 scroll_into_view
@@ -237,7 +237,7 @@ sub get_screen_position {
 sub focus {
     my ($self) = @_;
 
-    return decode_json $self->property_search('focus()');
+    return $self->property_search('focus()');
 }
 
 =head2 submit
@@ -301,7 +301,7 @@ sub is_visible {
         isVisible(element)
     ";
 
-    return decode_json $self->inspector->run_javascript($search);
+    return $self->inspector->run_javascript($search);
 }
 
 =head2 resolve_locator

--- a/t/mouse.t
+++ b/t/mouse.t
@@ -33,14 +33,14 @@ is($updated_select_value, 'testtwo', 'Test Two is the new selected value');
 $webkit->select('css=#body .form select[name="dropdown_list"]', 'label=Testone');
 
 my $radio_value = $webkit->resolve_locator('.//input[@id="radiotest_one"]')->property_search('checked');
-is($radio_value, '"false"', 'Radio value is currently false');
+is($radio_value, 'false', 'Radio value is currently false');
 $webkit->check('.//input[@id="radiotest_one"]');
 $radio_value = $webkit->resolve_locator('.//input[@id="radiotest_one"]')->property_search('checked');
-is($radio_value, '"true"', 'Radio is set to true');
+is($radio_value, 'true', 'Radio is set to true');
 
 $webkit->uncheck('.//input[@id="radiotest_one"]');
 $radio_value = $webkit->resolve_locator('.//input[@id="radiotest_one"]')->property_search('checked');
-is($radio_value, '"false"', 'Radio is now set to false');
+is($radio_value, 'false', 'Radio is now set to false');
 
 $webkit->mouse_over('.//li[@id="test_item_one"]');
 my $mouse_over_result = $webkit->resolve_locator('.//li[@id="test_item_new"]');


### PR DESCRIPTION
eval_js was not returning the real javascript result, but a JSON-object.
This became an issue when JSON.stringify was evaled for example.

pair-programmed with @RedGreatApe 
branchname courtesy of him as well.