### PR TITLE
Add a slight pause after a fire event, seems to be more reliable

### DIFF
--- a/lib/WWW/WebKit2/Locator.pm
+++ b/lib/WWW/WebKit2/Locator.pm
@@ -270,7 +270,9 @@ sub fire_event {
         element.dispatchEvent(event);
     ';
 
-    return $self->inspector->run_javascript($fire_event)
+    my $result = $self->inspector->run_javascript($fire_event);
+    $self->inspector->pause(100);
+    return $result;
 }
 
 =head2 is_visible


### PR DESCRIPTION
We were getting random fails in our test suite after events were fired. adding a pause increase reliability (same as it is done in the left_click mouse event already).