### PR TITLE
make is_element_present behave like previous WebKit version again

### DIFF
--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -326,6 +326,7 @@ sub init_webkit {
     });
 
     $self->enable_file_access_from_file_urls;
+    $self->enable_console_log;
 
     $self->window->show_all;
     $self->process_events;

--- a/lib/WWW/WebKit2/Inspector.pm
+++ b/lib/WWW/WebKit2/Inspector.pm
@@ -194,7 +194,7 @@ sub get_center_screen_position {
 sub is_element_present {
     my ($self, $locator) = @_;
 
-    return $self->resolve_locator($locator)->get_length > 0;
+    return $self->resolve_locator($locator)->get_length == 1;
 }
 
 =head3 is_visible($locator)

--- a/lib/WWW/WebKit2/Inspector.pm
+++ b/lib/WWW/WebKit2/Inspector.pm
@@ -30,11 +30,7 @@ sub get_javascript_result {
     my $value = $self->view->run_javascript_finish($result);
     my $js_value = $value->get_js_value;
 
-    return undef if $js_value->is_null;
-
-    return $js_value->to_string if $js_value->is_string;
-
-    my $json = JSON->new;
+    return undef if ($js_value->is_null or $js_value->is_undefined);
 
     return $js_value->to_string;
 }
@@ -194,7 +190,9 @@ sub get_center_screen_position {
 sub is_element_present {
     my ($self, $locator) = @_;
 
-    return $self->resolve_locator($locator)->is_unique;
+    my $result = eval { $self->resolve_locator($locator)->is_unique; };
+
+    return $result;
 }
 
 =head3 is_visible($locator)

--- a/lib/WWW/WebKit2/Inspector.pm
+++ b/lib/WWW/WebKit2/Inspector.pm
@@ -194,7 +194,7 @@ sub get_center_screen_position {
 sub is_element_present {
     my ($self, $locator) = @_;
 
-    return $self->resolve_locator($locator)->get_length == 1;
+    return $self->resolve_locator($locator)->is_unique;
 }
 
 =head3 is_visible($locator)

--- a/lib/WWW/WebKit2/Locator.pm
+++ b/lib/WWW/WebKit2/Locator.pm
@@ -195,7 +195,11 @@ sub set_value {
 sub is_unique {
     my ($self) = @_;
 
-    return defined $self->property_search('length');
+    my $function = "function x() { " . $self->prepare_element . " return element; } " .
+        "var element = x();
+        element === undefined ? 0 : 1";
+
+    return $self->inspector->run_javascript($function);
 }
 
 =head2 get_length

--- a/lib/WWW/WebKit2/Locator.pm
+++ b/lib/WWW/WebKit2/Locator.pm
@@ -354,6 +354,11 @@ my $get_elements_function = q{
         let results = [];
         let query = document.evaluate(xpath, parent || document,
             null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+
+        if (query.snapshotLength > 1) {
+            throw('xpath returned more than 1 result: ' + xpath);
+        }
+
         for (let i = 0, length = query.snapshotLength; i < length; ++i) {
             results.push(query.snapshotItem(i));
         }

--- a/lib/WWW/WebKit2/Locator.pm
+++ b/lib/WWW/WebKit2/Locator.pm
@@ -188,12 +188,22 @@ sub set_value {
     return $self->property_search('value = "' . $value . '";');
 }
 
+=head2 is_unique
+
+=cut
+
+sub is_unique {
+    my ($self) = @_;
+
+    return defined $self->property_search('length');
+}
+
 =head2 get_length
 
 =cut
 
 sub get_length {
-    my ($self, $attribute) = @_;
+    my ($self) = @_;
 
     my $search = $self->prepare_elements_search('length');
 

--- a/lib/WWW/WebKit2/LocatorCSS.pm
+++ b/lib/WWW/WebKit2/LocatorCSS.pm
@@ -30,7 +30,14 @@ sub prepare_element {
 
     my $locator = $self->resolved_locator;
 
-    my $search = "var $element_name = document.querySelector('$locator');";
+    my $search = "var $element_name = document.querySelectorAll('$locator');
+        if ($element_name.length > 1) {
+            throw('css returned more than 1 result: $locator');
+        }
+        else {
+            $element_name = $element_name\[0];
+        }
+    ";
 
     return $search;
 }

--- a/lib/WWW/WebKit2/Settings.pm
+++ b/lib/WWW/WebKit2/Settings.pm
@@ -17,11 +17,11 @@ sub enable_file_access_from_file_urls {
     return $self->save_settings($settings);
 }
 
-=head3 enable_write_console_messages_to_stdout
+=head3 enable_console_log
 
 =cut
 
-sub enable_write_console_messages_to_stdout {
+sub enable_console_log {
     my ($self) = @_;
 
     my $settings = $self->settings;

--- a/t/inspector.t
+++ b/t/inspector.t
@@ -98,7 +98,7 @@ is($webkit->get_confirmation, 'Confirm?', 'confirmation popped up');
 $webkit->run_javascript('alert("Alert!")');
 is($webkit->get_alert, 'Alert!', 'alert popped up');
 
-$webkit->enable_write_console_messages_to_stdout;
+$webkit->enable_console_log;
 $webkit->open("$Bin/test/console_error.html");
 $webkit->run_javascript('console.log("console log stdout test")');
 

--- a/t/inspector.t
+++ b/t/inspector.t
@@ -66,7 +66,7 @@ ok($webkit->is_element_present('css=#content'), 'css content is present');
 ok($webkit->is_element_present('xpath=//div[@id="content"]'), 'xpath content is present');
 ok(not($webkit->is_element_present('css=#foobar')), '#foobar is not present');
 ok(not($webkit->is_element_present('xpath=//div[@id="foobar"]')), 'xpath #foobar is not present');
-ok((not $webkit->is_element_present('css=*')), 'fail on multiple matches');
+ok((not $webkit->is_element_present('css=input')), 'fail on multiple matches');
 
 ok($webkit->is_ordered('css=head', 'css=body'), 'head > body order correct');
 ok($webkit->is_ordered('css=#content', 'css=form'), 'order correct');
@@ -98,7 +98,6 @@ is($webkit->get_confirmation, 'Confirm?', 'confirmation popped up');
 $webkit->run_javascript('alert("Alert!")');
 is($webkit->get_alert, 'Alert!', 'alert popped up');
 
-$webkit->enable_console_log;
 $webkit->open("$Bin/test/console_error.html");
 $webkit->run_javascript('console.log("console log stdout test")');
 

--- a/t/inspector.t
+++ b/t/inspector.t
@@ -66,6 +66,7 @@ ok($webkit->is_element_present('css=#content'), 'css content is present');
 ok($webkit->is_element_present('xpath=//div[@id="content"]'), 'xpath content is present');
 ok(not($webkit->is_element_present('css=#foobar')), '#foobar is not present');
 ok(not($webkit->is_element_present('xpath=//div[@id="foobar"]')), 'xpath #foobar is not present');
+ok((not $webkit->is_element_present('css=*')), 'fail on multiple matches');
 
 ok($webkit->is_ordered('css=head', 'css=body'), 'head > body order correct');
 ok($webkit->is_ordered('css=#content', 'css=form'), 'order correct');

--- a/t/locator.t
+++ b/t/locator.t
@@ -24,8 +24,8 @@ elsif ($@) {
 $webkit->open("$Bin/test/locator.html");
 ok(1, 'opened');
 
-my $xpath_length = $webkit->resolve_locator("xpath=//option")->get_length;
-is($xpath_length, "2", "got correct length with xpath");
+my $xpath_length = $webkit->resolve_locator("xpath=//option[1]")->get_length;
+is($xpath_length, "1", "got correct length with xpath");
 
 my $option = $webkit->resolve_locator("label=Testoption")->get_tag_name;
 is($option, "OPTION", "label resolved");


### PR DESCRIPTION
Previous webKit version resolve locator croaked when more than 1 match were found.

We might want to check all other stuff that uses resolve_locator as well, or check resolve_locator itself again.