### PR TITLE
Rework prepare_element logic.

### DIFF
--- a/lib/WWW/WebKit2/Inspector.pm
+++ b/lib/WWW/WebKit2/Inspector.pm
@@ -30,11 +30,7 @@ sub get_javascript_result {
     my $value = $self->view->run_javascript_finish($result);
     my $js_value = $value->get_js_value;
 
-    return undef if $js_value->is_null;
-
-    return $js_value->to_string if $js_value->is_string;
-
-    my $json = JSON->new;
+    return undef if ($js_value->is_null or $js_value->is_undefined);
 
     return $js_value->to_string;
 }
@@ -194,7 +190,9 @@ sub get_center_screen_position {
 sub is_element_present {
     my ($self, $locator) = @_;
 
-    return $self->resolve_locator($locator)->get_length > 0;
+    my $result = eval { $self->resolve_locator($locator)->prepare_element; };
+
+    return $result;
 }
 
 =head3 is_visible($locator)

--- a/lib/WWW/WebKit2/Locator.pm
+++ b/lib/WWW/WebKit2/Locator.pm
@@ -1,6 +1,7 @@
 package WWW::WebKit2::Locator;
 
 use common::sense;
+use Carp qw(croak);
 use JSON qw(decode_json encode_json);
 use Moose;
 
@@ -193,7 +194,7 @@ sub set_value {
 =cut
 
 sub get_length {
-    my ($self, $attribute) = @_;
+    my ($self) = @_;
 
     my $search = $self->prepare_elements_search('length');
 
@@ -384,8 +385,12 @@ sub prepare_element {
         $get_elements_function
         $parent
         var $element_name = getElementsByXPath('$locator'$parent_param);
-        $element_name = $element_name" . "[0];
     ";
+
+    my $count = $self->inspector->run_javascript($search . "$element_name.length;");
+    croak "xpath: $locator gave $count results" if $count != 1;
+
+    $search .= "$element_name = $element_name" . "[0];";
 
     return $search;
 }

--- a/lib/WWW/WebKit2/LocatorCSS.pm
+++ b/lib/WWW/WebKit2/LocatorCSS.pm
@@ -1,6 +1,7 @@
 package WWW::WebKit2::LocatorCSS;
 
 use common::sense;
+use Carp qw(croak);
 use Moose;
 use base 'WWW::WebKit2::Locator';
 
@@ -30,9 +31,11 @@ sub prepare_element {
 
     my $locator = $self->resolved_locator;
 
-    my $search = "var $element_name = document.querySelector('$locator');";
+    my $count = $self->inspector->run_javascript($self->prepare_elements_search('length'));
+    croak "css: $locator gave $count results" if $count != 1;
 
-    return $search;
+    return $self->prepare_elements .
+        "$element_name = elements[0];";
 }
 
 =head2 prepare_elements

--- a/lib/WWW/WebKit2/Settings.pm
+++ b/lib/WWW/WebKit2/Settings.pm
@@ -17,11 +17,11 @@ sub enable_file_access_from_file_urls {
     return $self->save_settings($settings);
 }
 
-=head3 enable_write_console_messages_to_stdout
+=head3 enable_console_log
 
 =cut
 
-sub enable_write_console_messages_to_stdout {
+sub enable_console_log {
     my ($self) = @_;
 
     my $settings = $self->settings;

--- a/t/inspector.t
+++ b/t/inspector.t
@@ -66,6 +66,10 @@ ok($webkit->is_element_present('css=#content'), 'css content is present');
 ok($webkit->is_element_present('xpath=//div[@id="content"]'), 'xpath content is present');
 ok(not($webkit->is_element_present('css=#foobar')), '#foobar is not present');
 ok(not($webkit->is_element_present('xpath=//div[@id="foobar"]')), 'xpath #foobar is not present');
+ok((not $webkit->is_element_present('css=input')), 'false on multiple css matches');
+ok((not $webkit->is_element_present('//input')), 'false on multiple xpath matches');
+ok((not $webkit->is_element_present('css=definitely_nothing')), 'false on 0 css matches');
+ok((not $webkit->is_element_present('//definitely_nothing')), 'false on 0 xpath matches');
 
 ok($webkit->is_ordered('css=head', 'css=body'), 'head > body order correct');
 ok($webkit->is_ordered('css=#content', 'css=form'), 'order correct');
@@ -97,7 +101,7 @@ is($webkit->get_confirmation, 'Confirm?', 'confirmation popped up');
 $webkit->run_javascript('alert("Alert!")');
 is($webkit->get_alert, 'Alert!', 'alert popped up');
 
-$webkit->enable_write_console_messages_to_stdout;
+$webkit->enable_console_log;
 $webkit->open("$Bin/test/console_error.html");
 $webkit->run_javascript('console.log("console log stdout test")');
 


### PR DESCRIPTION
Previous webkit croaked when resolve_locator found != 1 elements.
This change also makes is_element_present work like in previous version again.

I'm not sure if prepare_element is the correct place for this check, but it seemed to be the most central place. Thoughts?