### PR TITLE
Refactor get_javascript_result to return either the raw or DOM result

### DIFF
--- a/lib/WWW/WebKit2/Locator.pm
+++ b/lib/WWW/WebKit2/Locator.pm
@@ -307,7 +307,7 @@ sub fire_event {
     $self->inspector->wait_for_condition(sub {
         my $event_fired = $self->inspector->run_javascript("window.event_fired");
         # event_fired will be undef if the event triggered a page load
-        return 1 if (not defined $event_fired or $event_fired eq "fired");
+        return 1 if (not $event_fired or $event_fired eq "fired");
         return 0;
     });
 

--- a/t/mouse.t
+++ b/t/mouse.t
@@ -33,25 +33,25 @@ is($updated_select_value, 'testtwo', 'Test Two is the new selected value');
 $webkit->select('css=#body .form select[name="dropdown_list"]', 'label=Testone');
 
 my $radio_value = $webkit->resolve_locator('.//input[@id="radiotest_one"]')->property_search('checked');
-is($radio_value, 'false', 'Radio value is currently false');
+ok((not $radio_value), 'Radio value is currently false');
 $webkit->check('.//input[@id="radiotest_one"]');
 $radio_value = $webkit->resolve_locator('.//input[@id="radiotest_one"]')->property_search('checked');
-is($radio_value, 'true', 'Radio is set to true');
+ok($radio_value, 'Radio is set to true');
 
 $webkit->uncheck('.//input[@id="radiotest_one"]');
 $radio_value = $webkit->resolve_locator('.//input[@id="radiotest_one"]')->property_search('checked');
-is($radio_value, 'false', 'Radio is now set to false');
+ok((not $radio_value), 'Radio is now set to false');
 
 # checkboxes with click
 my $checkbox_value = $webkit->resolve_locator('.//input[@id="checkboxtest"]')->property_search('checked');
-is($checkbox_value, 'false', 'Radio value is currently false');
+ok((not $checkbox_value), 'Radio value is currently false');
 $webkit->click('.//input[@id="checkboxtest"]');
 $checkbox_value = $webkit->resolve_locator('.//input[@id="checkboxtest"]')->property_search('checked');
-is($checkbox_value, 'true', 'checkbox is set to true');
+ok($checkbox_value, 'checkbox is set to true');
 
 $webkit->click('.//input[@id="checkboxtest"]');
 $checkbox_value = $webkit->resolve_locator('.//input[@id="checkboxtest"]')->property_search('checked');
-is($checkbox_value, 'false', 'checkbox is now set to false');
+ok((not $checkbox_value), 'checkbox is now set to false');
 
 $webkit->mouse_over('.//li[@id="test_item_one"]');
 my $mouse_over_result = $webkit->resolve_locator('.//li[@id="test_item_new"]');


### PR DESCRIPTION
Webkit1 had access to both the dom and javascript.
This means you could get the string "undefined" via eval_js and an empty string via the dom
when asking for the same thing.

In Webkit2 we only have javascript, but the semantic difference of the return values should be preserved.