### PR TITLE
Fix drag and drop sometimes not firing a drop event

### DIFF
--- a/lib/WWW/WebKit2/MouseInput.pm
+++ b/lib/WWW/WebKit2/MouseInput.pm
@@ -297,15 +297,15 @@ sub native_drag_and_drop_to_object {
 
     # "move" mouse again to cause a dragover event on the target
     # otherwise a drop may not work
-    $self->move_mouse_abs($x, $y);
+    $self->move_mouse_abs($x, $y) for 1 .. 5;
     $self->pause($step_delay);
 
     $self->release_mouse_button(1);
     $self->pause($step_delay);
     $self->move_mouse_abs($x, $y);
     $self->pause($step_delay);
-    $self->is_loading;
 
+    $self->process_page_load;
 }
 
 1;


### PR DESCRIPTION
It works reliably after calling the move_mouse_abs 3 times.
Event delay is not an issue, the Flush is not the issue.
It appears to be the fake motion event.