### PR TITLE
Make the ugly hack introduced in facafc7 saner.

### DIFF
--- a/lib/WWW/WebKit2/Inspector.pm
+++ b/lib/WWW/WebKit2/Inspector.pm
@@ -44,7 +44,7 @@ sub get_javascript_result {
 sub resolve_locator {
     my ($self, $locator, $locator_parent) = @_;
 
-    $locator =~ s/'/"/g;
+    $locator =~ s/'/\\'/g;
 
     if (my ($css) = $locator =~ /^css=(.*)/) {
         return WWW::WebKit2::LocatorCSS->new({

--- a/t/locator.t
+++ b/t/locator.t
@@ -79,6 +79,8 @@ ok(not($webkit->is_visible("css=.invisible")), "span is invisible");
 is($webkit->resolve_locator("css=.positioned")->get_offset_width, 75, "offset width ok");
 is($webkit->resolve_locator("css=.positioned")->get_offset_height, 50, "offset height ok");
 
+# test single quotes within locator string
 ok ($webkit->resolve_locator("css=body input[name='username']")->get_tag_name);
+ok ($webkit->resolve_locator("//input[\@name='username']")->get_tag_name);
 
 done_testing;


### PR DESCRIPTION
This hack broke selectors with double quotes within single quotes.
Instead of replacing single with double, replacing single with quoted single
seems better.