### PR TITLE
Turns out fire_event is not needed after doing a javascript click()

### DIFF
--- a/lib/WWW/WebKit2/MouseInput.pm
+++ b/lib/WWW/WebKit2/MouseInput.pm
@@ -92,7 +92,6 @@ sub click {
 
     if ($tag eq 'input' and ($type eq 'checkbox' or $type eq 'radio')) {
         $element->property_search('click()');
-        $element->fire_event('change');
     }
     elsif (($tag eq 'input' and ($type eq 'submit' or $type eq 'image'))
         or $tag eq 'submit'


### PR DESCRIPTION
The errors we assumed were fixed by that actually seemed to have been caused by something else.