### PR TITLE
Connect to "finished" signal as well. Some ajax calls seem to be fast.

### DIFF
--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -375,6 +375,9 @@ sub handle_resource_request {
     $resource->signal_connect('received-data' => sub {
         delete $self->pending_requests->{"$request"};
     });
+    $resource->signal_connect('finished' => sub {
+        delete $self->pending_requests->{"$request"};
+    });
     $resource->signal_connect('failed' => sub {
         # If someone decides not to wait_for_pending_requests, this signal is received
         # during global destruction with $self being undefined.


### PR DESCRIPTION
Some requests seem to be finished as soon as they're started and never send out a received-data signal. Thus, there will forever be a pending request, which screws up certain tests (especially involving ajax).