### PR TITLE
Make fire_mouse_event always return a true-ish value.

### DIFF
--- a/lib/WWW/WebKit2/MouseInput.pm
+++ b/lib/WWW/WebKit2/MouseInput.pm
@@ -188,6 +188,8 @@ sub fire_mouse_event {
         element.dispatchEvent(clickEvent);
     ";
     $self->run_javascript($mouse_up_script);
+
+    return 1;
 }
 
 sub move_mouse_abs {


### PR DESCRIPTION
dispatchEvent does not return true if one event handler calls preventDefault.