### PR TITLE
Fire the change event after the wait_for_condition in select.

### DIFF
--- a/lib/WWW/WebKit2/MouseInput.pm
+++ b/lib/WWW/WebKit2/MouseInput.pm
@@ -29,13 +29,13 @@ sub select {
 
     $self->run_javascript($set_select);
 
+    $self->wait_for_condition(sub {
+        return $select->get_value eq $option_value;
+    });
+
     $select->fire_event('change');
 
     $self->process_page_load;
-
-    $self->wait_for_condition(sub {
-       return $select->get_value eq $option_value;
-    });
 
     return 1;
 }


### PR DESCRIPTION
It is possible that a change event triggers an ajax request that makes
removes the select or changes classes/attributes/elements etc in a way
that makes the given locator no longer match.