### PR TITLE
Click ajax

### DIFF
--- a/lib/WWW/WebKit2/MouseInput.pm
+++ b/lib/WWW/WebKit2/MouseInput.pm
@@ -97,9 +97,9 @@ sub click {
         $element->property_search('click()');
         $self->wait_for_condition(sub {
             $self->load_status eq 'started'
-        });
+        }, 100);
     }
-    else{
+    else {
         $element->fire_event('click');
     }
 

--- a/lib/WWW/WebKit2/Navigator.pm
+++ b/lib/WWW/WebKit2/Navigator.pm
@@ -10,6 +10,10 @@ use File::Slurper 'read_text';
 sub open {
     my ($self, $url) = @_;
 
+    # make sure previous page, if existing, has finished all its work and there are no
+    # ajax requests or the like stuck in the pipeline
+    $self->process_page_load;
+
     if ($url =~ /^http[s]?:/ or $url =~ /^file:/) {
         $self->view->load_uri($url);
     }
@@ -18,7 +22,6 @@ sub open {
     }
 
     $self->process_page_load;
-    Gtk3::main_iteration_do(0);
 }
 
 =head3 refresh()


### PR DESCRIPTION
Clicking a button does not always cause a new page to be opened but can also be initiating an ajax request. The logic now supports those cases without running into timeouts.
And we now make sure to wait for any pending slow requests from a previous page before opening a new one.