### PR TITLE
Remove unnecessary code in uninit. $self->window->destroy destroys all.

### DIFF
--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -429,23 +429,13 @@ sub setup_xvfb {
 sub uninit {
     my ($self) = @_;
 
-    if ($self->has_view) {
-        $self->scrolled_view->remove($self->view) if $self->has_scrolled_view and $self->scrolled_view and $self->view;
-        $self->view->destroy if $self->view;
-        $self->clear_view;
-    }
-
-    if ($self->has_scrolled_view) {
-        $self->window->remove($self->scrolled_view) if $self->has_window and $self->window and $self->scrolled_view;
-        $self->scrolled_view->destroy if $self->scrolled_view;
-        $self->clear_scrolled_view;
-    }
-
     if ($self->has_window) {
         $self->window->destroy if $self->window;
         $self->clear_window;
     }
 
+    $self->clear_view;
+    $self->clear_scrolled_view;
     $self->clear_display;
 }
 


### PR DESCRIPTION
Fix for:

GLib-GObject-WARNING **: g_object_set_valist: object class 'WebKitWebView' has no property named 'hadjustment' at /usr/lib/perl5/site_perl/5.18.2/x86_64-linux-thread-multi/Glib/Object/Introspection.pm line 67.

(controller_Invoice-Editor.t:4456): Gtk-CRITICAL **: gtk_bin_remove: assertion 'priv->child == child' failed