### PR TITLE
Do not delete pending request when received-data signal has been

### DIFF
--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -375,9 +375,6 @@ sub handle_resource_request {
 
     $self->pending_requests->{"$request"}++;
 
-    $resource->signal_connect('received-data' => sub {
-        delete $self->pending_requests->{"$request"};
-    });
     $resource->signal_connect('finished' => sub {
         delete $self->pending_requests->{"$request"};
     });


### PR DESCRIPTION
received.

The documentation states:
"This signal is emitted after response is received, every time new data has been received.
It's useful to know the progress of the resource load operation."

This sounds like it caused our wait_for_pending_requests to continue before the
request was actually completely finished in some cases.