### PR TITLE
change to how reload message works so static html pages can be reloaded

### DIFF
--- a/lib/WWW/WebKit2/Navigator.pm
+++ b/lib/WWW/WebKit2/Navigator.pm
@@ -31,8 +31,16 @@ sub open {
 sub refresh {
     my ($self) = @_;
 
-    $self->view->reload;
-    $self->process_page_load;
+    my $url = $self->view->get_uri();
+
+    if ($url =~ /^http[s]?:/ or $url =~ /^file:/) {
+        $self->view->reload;
+        $self->process_page_load;
+    }
+    else {
+        $self->view->load_html(read_text($url), $url);
+    }
+
 }
 
 =head3 go_back()

--- a/t/inspector.t
+++ b/t/inspector.t
@@ -117,7 +117,7 @@ $webkit->run_javascript('console.log("console log stdout test")');
 
 $webkit->open("$Bin/test/unload.html");
 ok($webkit->type_keys("name=test_text", 'testing refresh prompt'), 'text entered to encourage dialog prompt was successful');
-$webkit->refresh;
+$webkit->open("$Bin/test/console_error.html");
 #see: https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload$
 is($webkit->get_confirmation, "It should be Dialogue not dialog.", 'The dialogue box returned the custom message on unload');
 

--- a/t/navigator.t
+++ b/t/navigator.t
@@ -23,7 +23,11 @@ elsif ($@) {
 
 $webkit->open("$Bin/test/load.html");
 ok(1, 'opened');
+my $first_open = $webkit->get_html_source();
 $webkit->refresh;
+my $second_open = $webkit->get_html_source();
+is ($first_open, $second_open, 'Page refreshed correctly');
+
 $webkit->open("$Bin/test/type.html");
 $webkit->go_back;
 


### PR DESCRIPTION
Refresh does not work with pages displayed using `view->load_html` in WWW::WebKit2::Navigator::open. A small change to refresh and an alteration for t/inspector was needed since using refresh this way does not trigger the onbefore unload inside t/test/unload.html