### PR TITLE
Introduce methods for dealing with asynchronous page reloads.

### DIFF
--- a/lib/WWW/WebKit2/Events.pm
+++ b/lib/WWW/WebKit2/Events.pm
@@ -142,6 +142,45 @@ sub wait_for_alert {
     }, $timeout);
 }
 
+=head2 prepare_async_page_reload
+
+To be used in combination with wait_for_async_page_load.
+Use case: interaction that causes an ajax request that causes a page reload without any
+immediately visible changes.
+
+$self->prepare_async_page_load;
+
+<page interactions>
+
+$self->wait_for_async_page_load;
+
+=cut
+
+sub prepare_async_page_load {
+    my ($self, $variable_name) = @_;
+
+    $variable_name //= "webkit2_to_reload";
+
+    return $self->run_javascript("window.$variable_name = true;");
+}
+
+=head2 wait_for_async_page_load
+
+To be used in combination with prepare_async_page_load.
+
+=cut
+
+sub wait_for_async_page_load {
+    my ($self, $timeout, $variable_name) = @_;
+
+    $variable_name //= "webkit2_to_reload";
+
+    $self->wait_for_condition(sub {
+        not $self->run_javascript("window.$variable_name;");
+    }, $timeout);
+    $self->wait_for_page_to_load;
+}
+
 =head3 fire_event($locator, $event_type)
 
 =cut

--- a/t/events.t
+++ b/t/events.t
@@ -73,11 +73,16 @@ $httpd->run(sub {
 $webkit->enable_console_log;
 $webkit->open($httpd->endpoint);
 $webkit->run_javascript("window.ajax_url='" . $httpd->endpoint . "'");
-$webkit->click('css=button');
+$webkit->click('css=button#start_ajax');
 $webkit->wait_for_condition(sub {
     $webkit->resolve_locator("css=#ajax_result")->get_inner_html eq 'Hello World';
 });
 is($webkit->resolve_locator("css=#ajax_result")->get_inner_html, 'Hello World', 'waited for js');
+
+$webkit->prepare_async_page_load;
+$webkit->click('css=button#start_ajax_with_reload');
+$webkit->wait_for_async_page_load;
+ok((not $webkit->run_javascript('window.ajax_url')), 'page has been reloaded');
 
 is($webkit->run_javascript('document.cookie'), 'foo=bar', 'cookie set');
 $webkit->clear_cookies;

--- a/t/test/events.html
+++ b/t/test/events.html
@@ -43,6 +43,20 @@
                     };
                 });
 
+                document.querySelector('#start_ajax_with_reload').addEventListener('click', function(e) {
+                    let xhr = new XMLHttpRequest();
+                    xhr.open('GET', window.ajax_url);
+                    xhr.send();
+                    xhr.onload = function() {
+                        if (xhr.readyState === xhr.DONE && xhr.status === 200) {
+                            window.setTimeout(function() {
+                                console.log('reloading')
+                                window.location.reload(true);
+                            }, 1000);
+                        }
+                    };
+                });
+
                 document.cookie = 'foo=bar; path=/';
             }
         </script>
@@ -57,6 +71,7 @@
         </div>
 
         <button id="start_ajax">Start AJAX</button>
+        <button id="start_ajax_with_reload">Start AJAX with page reload</button>
         <div id="ajax_result"></div>
     </body>
 </html>


### PR DESCRIPTION
Some specific scenarios can invoke an ajax request that causes
a page reload afterwards without any immediately visible changes
to the html.
Use prepare_for_async_page_load -> page interaction -> wait_for_async_page_load
if other wait_for_* methods are not enough.