### PR TITLE
Use events pending method in fire event

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for WWW::WebKit2
 
-0.11 Mon Mar 23 15:27:00 CET 2020
+0.11 Fri July 24 15:27:00 CET 2020
 
 Changing drag and drop to use javascript rather than simulated mouse controls.
+Getting HTML source with webkit_web_resource_get_data_finish rather than with javascript
+Change to page waiting technique used inside fire event
+Addition of proxy settings via webkit network proxy
+
+0.111 Tue July 28 16:10:00 CET 2020
+Change to how page loading is checked in fire events.

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,3 +1,4 @@
+Changes
 lib/WWW/WebKit2.pm
 lib/WWW/WebKit2/Cookies.pm
 lib/WWW/WebKit2/Events.pm
@@ -6,7 +7,9 @@ lib/WWW/WebKit2/KeyboardInput.pm
 lib/WWW/WebKit2/Locator.pm
 lib/WWW/WebKit2/LocatorCSS.pm
 lib/WWW/WebKit2/MouseInput.pm
+lib/WWW/WebKit2/MouseInput/DragAndDropSimulator.pm
 lib/WWW/WebKit2/Navigator.pm
+lib/WWW/WebKit2/Proxy.pm
 lib/WWW/WebKit2/Settings.pm
 LICENSE
 Makefile.PL
@@ -19,6 +22,7 @@ t/events.t
 t/inspector.t
 t/keyboard.t
 t/locator.t
+t/logging.t
 t/mouse.t
 t/navigator.t
 t/test/attribute.html

--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -55,7 +55,7 @@ use XSLoader;
 use English '-no_match_vars';
 use POSIX qw<F_SETFD F_GETFD FD_CLOEXEC>;
 
-our $VERSION = '0.11';
+our $VERSION = '0.111';
 
 use constant DOM_TYPE_ELEMENT => 1;
 use constant ORDERED_NODE_SNAPSHOT_TYPE => 7;

--- a/lib/WWW/WebKit2/Locator.pm
+++ b/lib/WWW/WebKit2/Locator.pm
@@ -352,7 +352,7 @@ sub fire_event {
     # regardless of what javascript will be executed because of fire_event,
     # at least make sure to wait until we have a page to work with.
     Gtk3::main_iteration
-        while $self->inspector->is_loading or not $self->inspector->get_html_source;
+        while (Gtk3::events_pending);
 
     return $result;
 }


### PR DESCRIPTION
The combination of [is_loading ](https://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebView.html#webkit-web-view-is-loading) and get_html_source sometimes caused webkit2 to hang on pages where no error was present. Checking [gtk3.events_pending](https://valadoc.org/gtk+-3.0/Gtk.events_pending.html) appears to resolve the issue.