### PR TITLE
The "main_iteration while events_pending" loop causes hangs in rare cases

### DIFF
--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -383,15 +383,13 @@ sub pending {
 sub process_events {
     my ($self) = @_;
 
-    Gtk3::main_iteration_do(0);
-    Gtk3::main_iteration while Gtk3::events_pending;
+    Gtk3::main_iteration_do(0) while Gtk3::events_pending;
 }
 
 sub process_page_load {
     my ($self) = @_;
 
-    Gtk3::main_iteration_do(0);
-    Gtk3::main_iteration while Gtk3::events_pending or $self->is_loading;
+    Gtk3::main_iteration_do(0) while Gtk3::events_pending or $self->is_loading;
 }
 
 sub is_loading {

--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -383,12 +383,14 @@ sub pending {
 sub process_events {
     my ($self) = @_;
 
+    Gtk3::main_iteration_do(0);
     Gtk3::main_iteration while Gtk3::events_pending;
 }
 
 sub process_page_load {
     my ($self) = @_;
 
+    Gtk3::main_iteration_do(0);
     Gtk3::main_iteration while Gtk3::events_pending or $self->is_loading;
 }
 


### PR DESCRIPTION
Using a single main_iteration_do at the beginning seems to prevent this
issue from occuring.