### PR TITLE
Add 'once' option to helper event-listener in fire_event for cleanup

### DIFF
--- a/lib/WWW/WebKit2/Cookies.pm
+++ b/lib/WWW/WebKit2/Cookies.pm
@@ -22,7 +22,7 @@ sub clear_cookies {
         $clear_result = $manager->clear_finish($result);
     }, undef);
 
-    Gtk3::main_iteration while Gtk3::events_pending or not $done;
+    Gtk3::main_iteration_do(0) while Gtk3::events_pending or not $done;
 
     return $clear_result;
 }

--- a/lib/WWW/WebKit2/Inspector.pm
+++ b/lib/WWW/WebKit2/Inspector.pm
@@ -20,7 +20,7 @@ sub run_javascript {
         $js_result = $self->get_javascript_result($result, $raw, $javascript_string);
     }, undef);
 
-    Gtk3::main_iteration while Gtk3::events_pending or not $done;
+    Gtk3::main_iteration_do(0) while Gtk3::events_pending or not $done;
 
     return $js_result;
 }

--- a/lib/WWW/WebKit2/Locator.pm
+++ b/lib/WWW/WebKit2/Locator.pm
@@ -351,7 +351,7 @@ sub fire_event {
 
     # regardless of what javascript will be executed because of fire_event,
     # at least make sure to wait until we have a page to work with.
-    Gtk3::main_iteration
+    Gtk3::main_iteration_do(0)
         while (Gtk3::events_pending);
 
     return $result;

--- a/lib/WWW/WebKit2/Locator.pm
+++ b/lib/WWW/WebKit2/Locator.pm
@@ -336,7 +336,7 @@ sub fire_event {
         window.event_fired = "initialized";
         element.addEventListener("' . $event_type . '", function(e) {
            window.event_fired = "fired";
-        });
+        }, { once: true });
         var event = new Event("' . $event_type . '", { "bubbles": true, "cancelable": true });
         element.dispatchEvent(event);
     ';


### PR DESCRIPTION
This automatically removes it after it was invoked once.

There were also some more places that had called main_iteration, they now call main_iteration_do as well.