### PR TITLE
Get rid of "intelligent" waiting after click, as it clearly is not reliable

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,3 +9,9 @@ Addition of proxy settings via webkit network proxy
 
 0.111 Tue July 28 16:10:00 CET 2020
 Change to how page loading is checked in fire events.
+
+0.12 Wed Sep 16 11:20:00 CET 2020
+- Remove potential TOCTOU race condition caused usage of Gtk3::main_iteration
+- helper event listener in fire_event now cleans itself up
+- remove "intelligent" wait handling in click and implement click_and_wait instead.
+  Let the user handle the waiting.

--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -55,7 +55,7 @@ use XSLoader;
 use English '-no_match_vars';
 use POSIX qw<F_SETFD F_GETFD FD_CLOEXEC>;
 
-our $VERSION = '0.111';
+our $VERSION = '0.12';
 
 use constant DOM_TYPE_ELEMENT => 1;
 use constant ORDERED_NODE_SNAPSHOT_TYPE => 7;

--- a/lib/WWW/WebKit2/MouseInput.pm
+++ b/lib/WWW/WebKit2/MouseInput.pm
@@ -87,7 +87,7 @@ sub uncheck {
 }
 
 sub click {
-    my ($self, $locator) = @_;
+    my ($self, $locator, $wait) = @_;
 
     my $element = $self->resolve_locator($locator);
 
@@ -99,23 +99,25 @@ sub click {
     if ($tag eq 'input' and ($type eq 'checkbox' or $type eq 'radio')) {
         $element->property_search('click()');
     }
-    elsif (($tag eq 'input' and ($type eq 'submit' or $type eq 'image'))
-        or $tag eq 'submit'
-        or ($tag eq 'button' and $type eq 'submit')) {
-
-        $element->property_search('click()');
-        $self->wait_for_condition(sub {
-            $self->load_status eq 'started'
-        }, 100);
-    }
     else {
         $element->fire_event('click');
     }
 
+    if ($wait) {
+        $self->wait_for_condition(sub {
+            $self->is_loading;
+        });
+    }
 
     $self->process_page_load;
 
     return 1;
+}
+
+sub click_and_wait {
+    my ($self, $locator) = @_;
+
+    return $self->click($locator, 1);
 }
 
 sub left_click {


### PR DESCRIPTION
Instead let the caller specify if it needs to wait for a page load or not, by calling click_and_wait instead of click