### PR TITLE
Wait out any remaining pending requests before opening a new page.

### DIFF
--- a/lib/WWW/WebKit2/Navigator.pm
+++ b/lib/WWW/WebKit2/Navigator.pm
@@ -12,6 +12,7 @@ sub open {
 
     # make sure previous page, if existing, has finished all its work and there are no
     # ajax requests or the like stuck in the pipeline
+    $self->wait_for_pending_requests;
     $self->process_page_load;
 
     if ($url =~ /^http[s]?:/ or $url =~ /^file:/) {


### PR DESCRIPTION
We already had a comment stating to do this to prevent ajax requests
being stuck or interfering with the following page, but only used
process_page_load which is NOT the same as wait_for_pending_requests.