### PR TITLE
Allow multiple concurrent navigation requests.

### DIFF
--- a/Changes
+++ b/Changes
@@ -29,3 +29,6 @@ Change to how page loading is checked in fire events.
 
 0.124 Thu Oct 1 08:16:00 CET 2020
 - error correction for tests when run as root. Use ok in wrong position
+
+0.125 Mon Oct 5 13:15 CET 2020
+- allow multiple concurrent navigations (can be caused by iframes) and turn die into opt-in warn

--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -268,6 +268,11 @@ has 'active_navigation_action' => (
     default => 0,
 );
 
+has 'concurrent_active_navigation_warning' => (
+    is      => 'ro',
+    default => 0,
+);
+
 =head2 METHODS
 
 =head3 init
@@ -352,13 +357,20 @@ sub init_webkit {
         my ($view, $decision, $type) = @_;
         if ($type eq 'navigation-action') {
             my $action = $decision->get_navigation_action;
-            die "Already running a navigation action to " .
-                $self->active_navigation_action
-                . " when requested "
-                . $action->get_navigation_type . ' ' . $action->get_request->get_uri
-                if $self->active_navigation_action and not $action->is_redirect;
+
+            if ($self->concurrent_active_navigation_warning
+                and $self->active_navigation_action and not $action->is_redirect) {
+
+                warn "Already running a navigation action to " .
+                    $self->active_navigation_action
+                    . " when requested "
+                    . $action->get_navigation_type . ' ' . $action->get_request->get_uri;
+            }
+
             $self->active_navigation_action($action->get_request->get_uri)
-                if ($self->view->get_uri =~ s/#.*//r) ne ($action->get_request->get_uri =~ s/#.*//r);
+                if ($self->view->get_uri =~ s/#.*//r) ne ($action->get_request->get_uri =~ s/#.*//r)
+                    and not $action->is_redirect;
+
         }
         $decision->use;
         return 0;

--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -55,7 +55,7 @@ use XSLoader;
 use English '-no_match_vars';
 use POSIX qw<F_SETFD F_GETFD FD_CLOEXEC>;
 
-our $VERSION = '0.124';
+our $VERSION = '0.125';
 
 use constant DOM_TYPE_ELEMENT => 1;
 use constant ORDERED_NODE_SNAPSHOT_TYPE => 7;


### PR DESCRIPTION
It is possible to have multiple concurrent navigation requests when
iframes are used, so we cannot just die.

Turn the die into an opt-in warning and disallow redirects to set the
active_navigation_action as they don't seem to clear correctly.