### PR TITLE
Decide policy ignore about:blank

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,3 +32,6 @@ Change to how page loading is checked in fire events.
 
 0.125 Mon Oct 5 13:15 CET 2020
 - allow multiple concurrent navigations (can be caused by iframes) and turn die into opt-in warn
+
+0.126 Tue Oct 6 11:00 CET 2020
+- navigation requests to about:blank never properly finish and cause WebKit to hang

--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -55,7 +55,7 @@ use XSLoader;
 use English '-no_match_vars';
 use POSIX qw(F_SETFD F_GETFD FD_CLOEXEC);
 
-our $VERSION = '0.125';
+our $VERSION = '0.126';
 
 use constant DOM_TYPE_ELEMENT => 1;
 use constant ORDERED_NODE_SNAPSHOT_TYPE => 7;

--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -53,7 +53,7 @@ use X11::Xlib;
 use Carp qw(carp croak);
 use XSLoader;
 use English '-no_match_vars';
-use POSIX qw<F_SETFD F_GETFD FD_CLOEXEC>;
+use POSIX qw(F_SETFD F_GETFD FD_CLOEXEC);
 
 our $VERSION = '0.125';
 


### PR DESCRIPTION
Getting navigation requests to about:blank causes WebKit to hang, because these "requests" never finish.