### PR TITLE
Disregard all about:<something> uris in the navigation policy.

### DIFF
--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -375,6 +375,9 @@ sub init_webkit {
                     if ($self->view->get_uri =~ s/#.*//r) ne ($action->get_request->get_uri =~ s/#.*//r)
                         and not $action->is_redirect;
             }
+            else {
+                $self->active_navigation_action('');
+            }
         }
 
         $decision->use;
@@ -457,6 +460,10 @@ sub handle_resource_request {
     $resource->signal_connect('failed' => sub {
         # If someone decides not to wait_for_pending_requests, this signal is received
         # during global destruction with $self being undefined.
+        $self->active_navigation_action('') if $uri eq $self->active_navigation_action;
+        delete $self->pending_requests->{"$request"} if defined $self;
+    });
+    $resource->signal_connect('failed-with-tls-errors' => sub {
         $self->active_navigation_action('') if $uri eq $self->active_navigation_action;
         delete $self->pending_requests->{"$request"} if defined $self;
     });

--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -361,8 +361,7 @@ sub init_webkit {
             my $action = $decision->get_navigation_action;
             my $action_uri = $action->get_request->get_uri;
 
-            unless ($action_uri eq 'about:blank') {
-
+            unless ($action_uri =~ m/\A about:/x) {
                 if ($self->concurrent_active_navigation_warning
                     and $self->active_navigation_action and not $action->is_redirect) {
 

--- a/t/iframe_open.t
+++ b/t/iframe_open.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::More;
+use lib 'lib';
+use FindBin qw($Bin $RealBin);
+use lib "$Bin/../../Gtk3-WebKit2/lib";
+use URI;
+use WWW::WebKit2;
+
+#Running tests as root will sometimes spawn an X11 that cannot be closed automatically and leave the test hanging
+plan skip_all => 'Tests run as root may hang due to X11 server not closing.' unless $>;
+
+my $wkit = WWW::WebKit2->new(xvfb => 1);
+$wkit->init;
+
+$wkit->open("$Bin/test/iframe.html");
+ok(1, 'opened');
+
+done_testing;

--- a/t/iframe_open.t
+++ b/t/iframe_open.t
@@ -18,4 +18,5 @@ $wkit->init;
 $wkit->open("$Bin/test/iframe.html");
 ok(1, 'opened');
 
+$wkit->click('id=iframeDisplay');
 done_testing;

--- a/t/test/iframe.html
+++ b/t/test/iframe.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            iframe {
+                width: 200px;
+                height: 200px;
+            }
+        </style>
+
+        <script>
+        </script>
+    </head>
+    <body>
+
+    <div>beautiful testpage</div>
+
+    <iframe src="about:blank"></iframe>
+    <iframe src="about:help"></iframe>
+    <iframe src="about:config"></iframe>
+
+    </body>
+</html>

--- a/t/test/iframe.html
+++ b/t/test/iframe.html
@@ -18,6 +18,16 @@
     <iframe src="about:blank"></iframe>
     <iframe src="about:help"></iframe>
     <iframe src="about:config"></iframe>
+    </br>
+    <button id="iframe_open" onclick="displayIframe()" >click me</button>
+    </br>
+    <div id="iframeDisplay"></div>
 
+    <script>
+        function displayIframe() {
+            document.getElementById("iframeDisplay").innerHTML = "<iframe id=\"test_frame\" src=\"about:blank\"></iframe>";
+
+        }
+        </script>
     </body>
 </html>


### PR DESCRIPTION
We already discovered issues with about:blank requests, as these are not
regular navigation requests. These peculiarities extend to other about:
requests as well, so they should be disregarded in the decide-policy
handling too.

I'm not entirely sure this will help #80 , but it is a potential source for hanging during the 'open' call (running iframe_open.t without the changes to WebKit2.pm produces a hang)