### PR TITLE
Fix Xvfb support when Wayland is running

### DIFF
--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -499,6 +499,7 @@ sub setup_xvfb {
     my $display = <$read>;
     chomp $display;
 
+    $ENV{WAYLAND_DISPLAY} = '';
     $ENV{DISPLAY} = ":$display";
 
     return;


### PR DESCRIPTION
If Wayland is detected, it will be given preference to X, so we need to hide
Wayland in order for Xvfb to be actually used.