### PR TITLE
Massively reduce latency when waiting for conditions

### DIFF
--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -49,7 +49,6 @@ use Gtk3::Soup;
 use Glib qw(TRUE FALSE);
 use File::Path qw(make_path);
 use File::Slurper qw(write_text);
-use Time::HiRes qw(time usleep);
 use X11::Xlib;
 use Carp qw(carp croak);
 use XSLoader;

--- a/lib/WWW/WebKit2/Events.pm
+++ b/lib/WWW/WebKit2/Events.pm
@@ -1,7 +1,6 @@
 package WWW::WebKit2::Events;
 
 use Moose::Role;
-use Time::HiRes qw(time usleep);
 
 =head3 set_timeout($timeout)
 
@@ -22,17 +21,10 @@ sub set_timeout {
 sub pause {
     my ($self, $time) = @_;
 
-    my $expiry = time + $time / 1000;
-
-    while (1) {
-        $self->process_events;
-
-        if (time < $expiry) {
-            usleep 10000;
-        }
-        else {
-            last;
-        }
+    my $timed_out = 0;
+    my $source = Glib::Timeout->add($time, sub { $timed_out = 1; return 0; });
+    until ($timed_out) {
+        Gtk3::main_iteration;
     }
 }
 
@@ -52,16 +44,15 @@ sub wait_for_condition {
 
     $timeout ||= $self->default_timeout;
 
-    my $expiry = time + $timeout / 1000;
-
     $self->process_events;
 
     my $result;
-    until ($result = $condition->()) {
-        $self->process_events;
-        return 0 if time > $expiry;
-        usleep 10000;
+    my $timed_out = 0;
+    my $source = Glib::Timeout->add($timeout, sub { $timed_out = 1; return 0; });
+    until ($result = $condition->() or $timed_out) {
+        Gtk3::main_iteration;
     }
+    Glib::Source->remove($source) unless $timed_out;
 
     $self->process_events;
 

--- a/lib/WWW/WebKit2/KeyboardInput.pm
+++ b/lib/WWW/WebKit2/KeyboardInput.pm
@@ -106,7 +106,7 @@ sub key_press {
     $display->XTestFakeKeyEvent($shift_keycode, 0, 1) if $self->modifiers->{'shift'};
     $display->XFlush;
 
-    usleep 50000; # time for the X server to deliver the event
+    $self->pause(50); # time for the X server to deliver the event
 
     $self->process_page_load;
 


### PR DESCRIPTION
While we are in an usleep, we cannot process any events. These events however
may be necessary for making progress, i.e. getting to the condition that we're
actually waiting for. By processing events only every 10ms we were actually
starving the queue and protracted the whole process.

Fix by using a Glib timeout instead and use a blocking wait for new events.
This way the process will be woken up exactly when there's something to do
without delay and without unnecessary checking for new events.

Speeds up a large test suite from over an hour to just 10 minutes.