### PR TITLE
wait_for_condition: reduce check overhead

### DIFF
--- a/lib/WWW/WebKit2/Events.pm
+++ b/lib/WWW/WebKit2/Events.pm
@@ -49,9 +49,12 @@ sub wait_for_condition {
     my $result;
     my $timed_out = 0;
     my $source = Glib::Timeout->add($timeout, sub { $timed_out = 1; return 0; });
-    until ($result = $condition->() or $timed_out) {
-        Gtk3::main_iteration;
+
+    until ($timed_out or $result = $condition->()) {
+        Gtk3::main_iteration();
+        Gtk3::main_iteration_do(0) while Gtk3::events_pending;
     }
+
     Glib::Source->remove($source) unless $timed_out;
 
     $self->process_events;


### PR DESCRIPTION
ensure we process all pending events before checking a condition.
reduces the amount of checks (including calling to the JS interpreter)
by ~50%.