### PR TITLE
force DBUS_SESSION_BUS_ADDRESS /dev/null to prevent Xvfb hangs

### DIFF
--- a/lib/WWW/WebKit2.pm
+++ b/lib/WWW/WebKit2.pm
@@ -500,6 +500,7 @@ sub setup_xvfb {
 
     $ENV{WAYLAND_DISPLAY} = '';
     $ENV{DISPLAY} = ":$display";
+    $ENV{DBUS_SESSION_BUS_ADDRESS} = 'unix:abstract=/dev/null';
 
     return;
 }


### PR DESCRIPTION
Xvfb will stick around if there are connections remaining causing
WWW::WebKit2 to hang.

depending on your environgment webkit and/or Xvfb start/use dbus
which sticks around even after webkit exits preventing Xvfb from
quitting.